### PR TITLE
Add Error Handle

### DIFF
--- a/talk/BaseTableVC.swift
+++ b/talk/BaseTableVC.swift
@@ -10,7 +10,10 @@ import UIKit
 class BaseTableVC<Cell: UITableViewCell, Model: Codable>: UIViewController,UITableViewDataSource, UITableViewDelegate {
     
     // MARK: - NEED OVERRIDE
-    func loadData(success: (([Model]) -> Void)?) {
+    func loadData(
+        success: (([Model]) -> Void)?,
+        failure: ((LoaderError) -> Void)?
+    ) {
         fatalError()
     }
     
@@ -45,6 +48,12 @@ class BaseTableVC<Cell: UITableViewCell, Model: Codable>: UIViewController,UITab
             DispatchQueue.main.async {
                 self.models = models
                 self.tableView.reloadData()
+            }
+        } failure: { error in
+            DispatchQueue.main.async {
+                let alert = UIAlertController(title: "Error", message: error.message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                self.navigationController?.present(alert, animated: true, completion: nil)
             }
         }
     }

--- a/talk/LineDetailVC.swift
+++ b/talk/LineDetailVC.swift
@@ -33,7 +33,7 @@ final class LineDetailVC: BaseTableVC<LineDetailCell, LineDetailModel> {
     /// -H  "accept: application/json"
     /// -H  "Content-Type: application/json"
     /// -d "{  \"lineID\": \"251001\"}"
-    override func loadData(success: (([LineDetailModel]) -> Void)?) {
+    override func loadData(success: (([LineDetailModel]) -> Void)?, failure: ((LoaderError) -> Void)?) {
         let url = URL(string: Settings.apiDomain + "newTaipei/garbageTruck/detail")!
         var request: URLRequest = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -42,15 +42,11 @@ final class LineDetailVC: BaseTableVC<LineDetailCell, LineDetailModel> {
                 "line_id": "\(lineID)"
             }
             """
-        print(body)
         request.httpBody = body.data(using: .utf8)!
 
         let loadDataObject = SessionLoader<LineDetailContentModel>(request: request)
-        loadDataObject.loadData{
-            model in
-            dump(model)
-            success?(model.data)
-        }
+        let successHandle: (LineDetailContentModel) -> Void = { success?($0.data) }
+        loadDataObject.loadData (success: successHandle, failure: failure)
     }
     
     override func configCell(model: LineDetailModel, cell: LineDetailCell) {

--- a/talk/LineVC.swift
+++ b/talk/LineVC.swift
@@ -25,7 +25,7 @@ final class LineVC: BaseTableVC<LineInfoCell, LineInfoModel> {
         title = area + " 路線清單"
     }
     
-    override func loadData(success: (([LineInfoModel]) -> Void)?) {
+    override func loadData(success: (([LineInfoModel]) -> Void)?, failure: ((LoaderError) -> Void)?) {
         let url = URL(string: Settings.apiDomain + "newTaipei/garbageTruck/lines")!
         var request: URLRequest = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -37,10 +37,8 @@ final class LineVC: BaseTableVC<LineInfoCell, LineInfoModel> {
 
 
         let loadDataObject = SessionLoader<LineContentModel>(request: request)
-        loadDataObject.loadData{
-            model in
-            success?(model.data)
-        }
+        let successHandle: (LineContentModel) -> Void = { success?($0.data) }
+        loadDataObject.loadData (success: successHandle, failure: failure)
     }
     
     override func configCell(model: LineInfoModel, cell: LineInfoCell) {

--- a/talk/MainVC.swift
+++ b/talk/MainVC.swift
@@ -13,7 +13,7 @@ final class MainVC: BaseTableVC<AreaCell, String> {
         super.viewDidLoad()
         title = "區域表"
     }
-    override func loadData(success: (([String]) -> Void)?) {
+    override func loadData(success: (([String]) -> Void)?, failure: ((LoaderError) -> Void)?) {
         guard
             let url = URL(string: Settings.apiDomain + "newTaipei/garbageTruck/area") else {
             // precondition < assert < fatalError
@@ -23,10 +23,8 @@ final class MainVC: BaseTableVC<AreaCell, String> {
         request.httpMethod = "POST"
         
         let loadDataObject = SessionLoader<AreaContentModel>(request: request)
-        loadDataObject.loadData{
-            model in
-            success?(model.data)
-        }
+        let successHandle: (AreaContentModel) -> Void = { success?($0.data) }
+        loadDataObject.loadData (success: successHandle, failure: failure)
     }
     
     override func configCell(model: String, cell: AreaCell) {

--- a/talk/SessionLoader.swift
+++ b/talk/SessionLoader.swift
@@ -18,27 +18,51 @@ import Foundation
 /// 3. Decodable 的型別
 ///
 
+enum LoaderError {
+    case urlSessionError(Error)
+    case noData
+    case decodeError(Error)
+    
+    var message: String {
+        switch self {
+        case let .urlSessionError(err):
+            return err.localizedDescription
+        case .noData:
+            return "Server return empty data"
+        case let .decodeError(err):
+            return err.localizedDescription
+        }
+    }
+}
+
 class SessionLoader<DecodeType : Decodable> {
+    
    init(request: URLRequest) {
         self.request = request
     }
     
-    
     let request: URLRequest
     
     @discardableResult
-    func loadData(success: ((DecodeType) -> Void)?) -> URLSessionTask {
+    func loadData(
+        success: ((DecodeType) -> Void)?,
+        failure: ((LoaderError) -> Void)?
+    ) -> URLSessionTask {
     
-        let task = URLSession.shared.dataTask(with: self.request) { data, res, err in
+        let task = URLSession.shared.dataTask(with: request) { data, res, err in
             if err != nil {
+                failure?(.urlSessionError(err!))
                 return
             }
-            guard let data = data else { return }
+            guard let data = data else {
+                failure?(.noData)
+                return
+            }
             do {
                 let model = try JSONDecoder().decode(DecodeType.self, from: data)
                 success?(model)
             } catch {
-                print(error)
+                failure?(.decodeError(error))
                 return
             }
             

--- a/talk/SessionLoader.swift
+++ b/talk/SessionLoader.swift
@@ -50,8 +50,8 @@ class SessionLoader<DecodeType : Decodable> {
     ) -> URLSessionTask {
     
         let task = URLSession.shared.dataTask(with: request) { data, res, err in
-            if err != nil {
-                failure?(.urlSessionError(err!))
+            if let err = err {
+                failure?(.urlSessionError(err))
                 return
             }
             guard let data = data else {


### PR DESCRIPTION
# Error Handle

一個 api call 過程當中會有許多 Error
但是外部不必要全部都要知道
所以定義一個 LoaderError，讓外部可以根據幾個特定狀態處理
而不用猜測 Error 的來源